### PR TITLE
Fix missing jsonschema dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ streamlit>=1.24.0
 lxml>=4.9.2
 xmlschema>=2.3.0
 streamlit-tree-select>=0.0.5
+jsonschema>=4.0.0
 
 # Testing dependencies
 pytest>=7.0.0


### PR DESCRIPTION
## Summary

Adds missing `jsonschema` dependency to requirements.txt to prevent ImportError when using JSON configuration validation.

### 🐛 Problem Fixed

• **Critical Missing Dependency**: `jsonschema` package was imported in `utils/config_manager.py` but not listed in requirements.txt
• **Impact**: Would cause `ImportError` when config validation features are used
• **Location**: `utils/config_manager.py:14` - `import jsonschema`

### 🔧 Solution

• Added `jsonschema>=4.0.0` to requirements.txt
• Ensures JSON configuration validation works correctly
• Prevents runtime errors in ConfigManager functionality

### ✅ Verification

- [x] Confirmed jsonschema is imported in utils/config_manager.py
- [x] Verified no other missing external dependencies
- [x] All built-in Python modules properly excluded from requirements

## Test plan

- [x] Install fresh environment with updated requirements.txt
- [x] Verify JSON configuration validation works without ImportError
- [x] Confirm all other imports still function correctly

🤖 Generated with [Claude Code](https://claude.ai/code)